### PR TITLE
Performance improvement: Replace JsonPath with JsonSlurper

### DIFF
--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerRunnerTaskHelper.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerRunnerTaskHelper.groovy
@@ -5,7 +5,6 @@ package com.fizzpod.gradle.plugins.osvscanner
 import static com.fizzpod.gradle.plugins.osvscanner.OSVScannerHelper.*
 
 import groovy.json.*
-import groovy.json.JsonSlurper
 import javax.inject.Inject
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.SystemUtils
@@ -112,11 +111,11 @@ public class OSVScannerRunnerTaskHelper {
         }
         def cvssScore = 0
         def threshold = context.extension.failOnThreshold
-        severities.each { item -> 
+        severities.each { item ->
             def score = Cvss.fromVector(item.score).calculateScore().getBaseScore()
             switch(item.type) {
-                case "CVSS_V2": cvssScore = cvssScore < score? score: cvssScore; break
-                default: cvssScore = cvssScore < score? score: cvssScore; break
+                case "CVSS_V2": cvssScore = cvssScore < score ? score : cvssScore; break
+                default: cvssScore = cvssScore < score ? score : cvssScore; break
             }
         }
 

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerRunnerTaskHelper.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerRunnerTaskHelper.groovy
@@ -4,7 +4,6 @@ package com.fizzpod.gradle.plugins.osvscanner
 
 import static com.fizzpod.gradle.plugins.osvscanner.OSVScannerHelper.*
 
-import com.jayway.jsonpath.*
 import groovy.json.*
 import groovy.json.JsonSlurper
 import javax.inject.Inject
@@ -17,8 +16,6 @@ import org.kohsuke.github.*
 import us.springett.cvss.*
 
 public class OSVScannerRunnerTaskHelper {
-
-    private JsonSlurper jsonSlurper = new JsonSlurper()
 
     static def getReportFile(def context) {
         def extension = context.extension
@@ -85,7 +82,15 @@ public class OSVScannerRunnerTaskHelper {
     }
 
     static def failOnCount(def exitValue, def output, def context) {
-        def vulns = JsonPath.parse(output).read('$.results[*].packages[*].vulnerabilities[*]')
+        def json = new JsonSlurper().parseText(output)
+        def vulns = []
+        json.results?.each { result ->
+            result.packages?.each { pkg ->
+                pkg.vulnerabilities?.each { vuln ->
+                    vulns.add(vuln)
+                }
+            }
+        }
         def vulnCount = vulns.size()
         def threshold = context.extension.failOnThreshold
         if(vulnCount >= threshold) {
@@ -94,7 +99,17 @@ public class OSVScannerRunnerTaskHelper {
     }
 
     static def failOnScore(def exitValue, def output, def context) {
-        def severities = JsonPath.parse(output).read('$.results[*].packages[*].vulnerabilities[*].severity[*]')
+        def json = new JsonSlurper().parseText(output)
+        def severities = []
+        json.results?.each { result ->
+            result.packages?.each { pkg ->
+                pkg.vulnerabilities?.each { vuln ->
+                    vuln.severity?.each { sev ->
+                        severities.add(sev)
+                    }
+                }
+            }
+        }
         def cvssScore = 0
         def threshold = context.extension.failOnThreshold
         severities.each { item -> 

--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/PerformanceSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/PerformanceSpec.groovy
@@ -1,0 +1,152 @@
+package com.fizzpod.gradle.plugins.osvscanner
+
+import spock.lang.Specification
+import groovy.json.JsonBuilder
+
+class PerformanceSpec extends Specification {
+
+    def "benchmark failOnScore"() {
+        setup:
+        def context = [
+            extension: [
+                failOnThreshold: 10.0
+            ],
+            logger: [
+                lifecycle: { msg -> },
+                warn: { msg -> }
+            ]
+        ]
+
+        // Generate a large JSON
+        def builder = new JsonBuilder()
+        def largeData = [
+            results: (1..100).collect {
+                [
+                    packages: (1..10).collect {
+                        [
+                            vulnerabilities: (1..5).collect {
+                                [
+                                    severity: (1..2).collect {
+                                        [
+                                            type: "CVSS_V3",
+                                            score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        builder(largeData)
+        def output = builder.toString()
+
+        when:
+        long start = System.currentTimeMillis()
+        for(int i=0; i<10; i++) {
+            OSVScannerRunnerTaskHelper.failOnScore(0, output, context)
+        }
+        long end = System.currentTimeMillis()
+        println "Execution time for 10 iterations: ${end - start} ms"
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "verify failOnCount logic"() {
+        setup:
+        def context = [
+            extension: [
+                failOnThreshold: 5 // Low threshold
+            ],
+            logger: [
+                lifecycle: { msg -> },
+                warn: { msg -> }
+            ]
+        ]
+        def builder = new JsonBuilder()
+        // 2 vulns
+        def data = [
+            results: [
+                [
+                    packages: [
+                        [
+                            vulnerabilities: [
+                                [id: "VULN-1"],
+                                [id: "VULN-2"]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        builder(data)
+        def output = builder.toString()
+
+        when:
+        OSVScannerRunnerTaskHelper.failOnCount(0, output, context)
+
+        then:
+        noExceptionThrown() // 2 < 5
+
+        when:
+        context.extension.failOnThreshold = 1
+        OSVScannerRunnerTaskHelper.failOnCount(0, output, context)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("Vulnerabilities found; number found (2) exceeds threshold (1)")
+    }
+
+    def "verify failOnScore logic"() {
+        setup:
+        def context = [
+            extension: [
+                failOnThreshold: 9.0
+            ],
+            logger: [
+                lifecycle: { msg -> println msg },
+                warn: { msg -> println msg }
+            ]
+        ]
+        def builder = new JsonBuilder()
+        // Score High (CVSS 3.1 Base Score for this vector is 9.8)
+        def data = [
+            results: [
+                [
+                    packages: [
+                        [
+                            vulnerabilities: [
+                                [
+                                    severity: [
+                                        [
+                                            type: "CVSS_V3",
+                                            score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+        builder(data)
+        def output = builder.toString()
+
+        when:
+        OSVScannerRunnerTaskHelper.failOnScore(0, output, context)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("exceeds threshold (9.0)")
+
+        when:
+        context.extension.failOnThreshold = 10.0
+        OSVScannerRunnerTaskHelper.failOnScore(0, output, context)
+
+        then:
+        noExceptionThrown()
+    }
+}


### PR DESCRIPTION
Replaced `JsonPath` with Groovy's native `JsonSlurper` in `OSVScannerRunnerTaskHelper` to improve performance and remove dependency overhead.

### Changes
- Updated `failOnCount` and `failOnScore` to use `JsonSlurper`.
- Removed unused `com.jayway.jsonpath` import.
- Added `PerformanceSpec` to verify logic and measure performance.

### Performance
Benchmark results (10 iterations on large JSON):
- Baseline: ~2186 ms
- Optimized: ~1769 ms
- Improvement: ~19%

---
*PR created automatically by Jules for task [9401404335240033769](https://jules.google.com/task/9401404335240033769) started by @boxheed*