### PR TITLE
Add assertions to osvScannerLicencesSummaryTask test

### DIFF
--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024-2025 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 

--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
@@ -95,8 +95,11 @@ class OSVScannerPluginSpec extends Specification {
             def task = project.getTasksByName(OSVScannerLicencesSummaryTask.NAME, false).iterator().next()
             task.runTask()
         then: 
-            //TODO proper assertion
             !project.getTasksByName(OSVScannerLicencesSummaryTask.NAME, false).isEmpty()
+            def report = new File(project.buildDir, "osv-scanner/osv-scanner-exp-lic-sum.json")
+            report.exists()
+            def json = new groovy.json.JsonSlurper().parse(report)
+            json.size() > 0
     }
 
     def "run osvScannerLicencesTask"() {


### PR DESCRIPTION
Implemented proper assertion for `run osvScannerLicencesSummaryTask` in `OSVScannerPluginSpec.groovy`. The test now checks for the existence of the generated JSON report and verifies it is not empty.

---
*PR created automatically by Jules for task [6181660678240241110](https://jules.google.com/task/6181660678240241110) started by @boxheed*