### PR TITLE
Add assertion for OSVScannerLicencesTask in OSVScannerPluginSpec

### DIFF
--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
@@ -1,7 +1,8 @@
-/* (C) 2024-2025 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
+import groovy.json.JsonSlurper
 import org.apache.commons.io.FileUtils
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -10,7 +11,6 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.*
 import spock.util.io.*
-import groovy.json.JsonSlurper
 
 class OSVScannerPluginSpec extends Specification {
 

--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
@@ -10,6 +10,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.*
 import spock.util.io.*
+import groovy.json.JsonSlurper
 
 class OSVScannerPluginSpec extends Specification {
 
@@ -117,6 +118,11 @@ class OSVScannerPluginSpec extends Specification {
         then: 
             //TODO proper assertion
             !project.getTasksByName(OSVScannerLicencesTask.NAME, false).isEmpty()
+            def reportFile = new File(project.buildDir, "osv-scanner/osv-scanner-exp-lic.json")
+            reportFile.exists()
+            def json = new JsonSlurper().parseText(reportFile.text)
+            json.license_summary != null
+            !json.license_summary.isEmpty()
     }
 
         def "run OSVScannerScanTask"() {


### PR DESCRIPTION
Implemented proper assertion for `run osvScannerLicencesTask` in `OSVScannerPluginSpec.groovy`. The test now verifies that the report file is generated and contains a non-empty `license_summary`. This ensures the task is functioning correctly. verified the logic by running the test with a workaround for the build environment issues.

---
*PR created automatically by Jules for task [79148387405550111](https://jules.google.com/task/79148387405550111) started by @boxheed*