### PR TITLE
Implement assertions for osvScannerInstallAllTask test

### DIFF
--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024-2025 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 

--- a/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
+++ b/buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy
@@ -73,8 +73,15 @@ class OSVScannerPluginSpec extends Specification {
             def task = project.getTasksByName(OSVScannerInstallAllTask.NAME, false).iterator().next()
             task.runTask()
         then: 
-            //TODO proper assertion
             !project.getTasksByName(OSVScannerInstallAllTask.NAME, false).isEmpty()
+            def installDir = new File(root, ".osv-scanner")
+            installDir.exists()
+            new File(installDir, "osv-scanner_linux_amd64").exists()
+            new File(installDir, "osv-scanner_linux_arm64").exists()
+            new File(installDir, "osv-scanner_darwin_amd64").exists()
+            new File(installDir, "osv-scanner_darwin_arm64").exists()
+            new File(installDir, "osv-scanner_windows_amd64.exe").exists()
+            new File(installDir, "osv-scanner_windows_arm64.exe").exists()
     }
 
 


### PR DESCRIPTION
Implemented proper assertions for `osvScannerInstallAllTask` test case in `buildSrc/src/test/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerPluginSpec.groovy`.
The assertions verify that the task downloads the expected binaries for Linux, macOS, and Windows (AMD64 and ARM64).
Verified binary naming convention against `OSVScannerInstallHelper.groovy` and confirmed availability of `windows_arm64` binary in upstream releases.
Note: The test execution might be slow or timeout in restricted environments due to network downloads, but the logic is correct.

---
*PR created automatically by Jules for task [530792726202030287](https://jules.google.com/task/530792726202030287) started by @boxheed*