### PR TITLE
fix(ADRiAn): Automated fix for dependency update failure

### DIFF
--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerDeleteLockfilesTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerDeleteLockfilesTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 
+@org.gradle.api.tasks.UntrackedTask(because="Deletes lockfiles")
 public class OSVScannerDeleteLockfilesTask extends DefaultTask {
 
     public static final String NAME = "deleteLockfiles"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerInstallAllTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerInstallAllTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
@@ -12,6 +12,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 
+@org.gradle.api.tasks.UntrackedTask(because="Downloads and installs binaries")
 public class OSVScannerInstallAllTask extends OSVScannerInstallTask {
 
     public static final String NAME = "osvInstallAll"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerInstallTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerInstallTask.groovy
@@ -13,6 +13,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.kohsuke.github.*
 
+@org.gradle.api.tasks.UntrackedTask(because="Downloads and installs binaries")
 public class OSVScannerInstallTask extends DefaultTask {
 
     public static final String NAME = "osvInstall"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLicencesSummaryTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLicencesSummaryTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024-2025 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.kohsuke.github.*
 
+@org.gradle.api.tasks.UntrackedTask(because="Generates reports")
 public class OSVScannerLicencesSummaryTask extends DefaultTask {
 
     public static final String NAME = "osvLicencesSummary"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLicencesTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLicencesTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024-2025 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.kohsuke.github.*
 
+@org.gradle.api.tasks.UntrackedTask(because="Generates reports")
 public class OSVScannerLicencesTask extends DefaultTask {
 
     public static final String NAME = "osvLicences"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLockAndScanTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLockAndScanTask.groovy
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 
+@org.gradle.api.tasks.UntrackedTask(because="Generates reports")
 public class OSVScannerLockAndScanTask extends DefaultTask {
 
     public static final String NAME = "osvLockAndScan"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLockfileTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerLockfileTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.kohsuke.github.*
 
+@org.gradle.api.tasks.UntrackedTask(because="Generates reports")
 public class OSVScannerLockfileTask extends DefaultTask {
 
     public static final String NAME = "osvLockfile"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerSbomTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerSbomTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.kohsuke.github.*
 
+@org.gradle.api.tasks.UntrackedTask(because="Generates reports")
 public class OSVScannerSbomTask extends DefaultTask {
 
     public static final String NAME = "osvSbom"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerScanTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerScanTask.groovy
@@ -1,4 +1,4 @@
-/* (C) 2024 */
+/* (C) 2024-2026 */
 /* SPDX-License-Identifier: Apache-2.0 */
 package com.fizzpod.gradle.plugins.osvscanner
 
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.kohsuke.github.*
 
+@org.gradle.api.tasks.UntrackedTask(because="Generates reports")
 public class OSVScannerScanTask extends DefaultTask {
 
     public static final String NAME = "osvScan"

--- a/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerWriteLockfilesTask.groovy
+++ b/buildSrc/src/main/groovy/com/fizzpod/gradle/plugins/osvscanner/OSVScannerWriteLockfilesTask.groovy
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 
+@org.gradle.api.tasks.UntrackedTask(because="Generates reports")
 public class OSVScannerWriteLockfilesTask extends DefaultTask {
 
     public static final String NAME = "writeLockfiles"


### PR DESCRIPTION
Fixes a CI build failure caused by updating the gradle-wrapper to version 9.4.1. Newer versions of Gradle strictly enforce task caching definitions during plugin validation. To satisfy the validation requirements and retain expected behavior without writing extensive custom input/output tracking annotations, all custom OSVScanner tasks in the plugin have been annotated with `@org.gradle.api.tasks.UntrackedTask(because="...")`. `spotlessApply` was also executed to format updated copyright strings in the headers.

---
*PR created automatically by Jules for task [17306646657243601396](https://jules.google.com/task/17306646657243601396) started by @boxheed*